### PR TITLE
Admin: Add change handler to currency

### DIFF
--- a/src/components/pages/Admin/Products/AdminProductsEdit.js
+++ b/src/components/pages/Admin/Products/AdminProductsEdit.js
@@ -374,6 +374,7 @@ class AdminProductsEdit extends React.Component {
                                     <InputField label={intlStore.getMessage(intlData, 'currency')}
                                                 labelSize="small" labelWeight="normal"
                                                 value={this.state.product.pricing.currency}
+                                                onChange={this.handlePricingChange.bind(null, 'currency')}
                                                 error={fieldError('pricing.currency')} />
                                     <InputField label={intlStore.getMessage(intlData, 'listPrice')}
                                                 labelSize="small" labelWeight="normal"


### PR DESCRIPTION
When updating an item in the admin panel, the currency will never be updated because the change handler doesn't exist. This causes the save request to fail.

This PR adds a change handler consistent with the other inputs to resolve this issue.